### PR TITLE
[Fix] 배경이미지 짤리는 문제 해결

### DIFF
--- a/JunctionAsia_Lomon_Soda/View/IntroView.swift
+++ b/JunctionAsia_Lomon_Soda/View/IntroView.swift
@@ -12,7 +12,8 @@ struct IntroView: View {
         ZStack{
             Image("MainViewBackGround")
                 .resizable()
-                .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height, alignment: .center)
+                .ignoresSafeArea()
+                .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
             rabbit()
             VStack(spacing: 10){
                 Text("NFiTion")

--- a/JunctionAsia_Lomon_Soda/View/MainView.swift
+++ b/JunctionAsia_Lomon_Soda/View/MainView.swift
@@ -19,8 +19,8 @@ struct MainView: View {
         ZStack {
             Image("ExhibitionViewBackGround")
                 .resizable()
-                .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height, alignment: .center)
-            
+                .ignoresSafeArea()
+                .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
             VStack {
                 HStack(spacing: 80) {
                     ForEach(artWorks, id: \.id) { artWork in


### PR DESCRIPTION
위아래 하얀색으로 이미지가 짤리는 문제를 해결했습니다. zstack으로 이미지를 쌓고, 이미지의 크기를 조절할때  순서가 중요하군요! 
```swift
Image()
    .resizable()
    .ignoreSafeArea()
    .frame()
```

변경화면! 
|Intro View| Main View|
|---|---|
|![simulator_screenshot_2FC02C56-3D98-4CDB-B2BB-5EB1C3B47239](https://user-images.githubusercontent.com/96969693/185767954-07aa37af-d06a-463c-964d-edcbf5391c93.png)|![simulator_screenshot_F91023F5-B10C-4B09-BBDF-E050C2507EC8](https://user-images.githubusercontent.com/96969693/185767958-59252063-fe34-4aa2-be05-745e34fda810.png)|
